### PR TITLE
build: update pnpm and node versions in CI

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -9,7 +9,7 @@ inputs:
   version: # id of input
     description: 'The version to use'
     required: false
-    default: 9.9.0
+    default: 10.7.0
 
 runs:
   using: 'composite'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.15.1]
+        node: [23.6.1]
         os: [ubuntu-latest]
 
     steps:
@@ -29,7 +29,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10.7.0
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
- Upgrade pnpm from 9.9.0 to 10.7.0 in GitHub Action
- Update Node.js version from 20.15.1 to 23.6.1 in test workflow
- Adjust pnpm version in test workflow to match action setup